### PR TITLE
fix: system given path mis-handled on windows

### DIFF
--- a/lib/platforms/android.dart
+++ b/lib/platforms/android.dart
@@ -227,7 +227,8 @@ void _createNewMainActivity({
         ..createSync(recursive: true);
       for (final element in oldDirContents) {
         element.renameSync(
-          '$langDir/$newPackageDirs/${element.path.split('/').last}',
+          '$langDir/$newPackageDirs/'
+          '${element.path.split(Platform.pathSeparator).last}',
         );
       }
 


### PR DESCRIPTION
Use platform specific path separator to split system given paths to retrieve last element.

fixes #21