### PR TITLE
added underscore smybol in PRODUCT_BUNDLE_IDENTIFIER regex matching

### DIFF
--- a/lib/platforms/ios.dart
+++ b/lib/platforms/ios.dart
@@ -126,7 +126,7 @@ void _setIOSPackageName(dynamic packageName) {
         // `PRODUCT_BUNDLE_IDENTIFIER = "{{BUNDLE_ID}}.{{EXTENSION_NAME}}";`
         .replaceAllMapped(
       RegExp(
-        r'PRODUCT_BUNDLE_IDENTIFIER = "([A-Za-z0-9.-_]+)\.([A-Za-z0-9.-_]+)";',
+        r'PRODUCT_BUNDLE_IDENTIFIER = ([A-Za-z0-9.-_]+)\.([A-Za-z0-9.-_]+);',
       ),
       (match) {
         final extensionName = match.group(2);

--- a/lib/platforms/ios.dart
+++ b/lib/platforms/ios.dart
@@ -126,7 +126,7 @@ void _setIOSPackageName(dynamic packageName) {
         // `PRODUCT_BUNDLE_IDENTIFIER = "{{BUNDLE_ID}}.{{EXTENSION_NAME}}";`
         .replaceAllMapped(
       RegExp(
-        r'PRODUCT_BUNDLE_IDENTIFIER = ([A-Za-z0-9.-_]+)\.([A-Za-z0-9.-_]+);',
+        r'PRODUCT_BUNDLE_IDENTIFIER = "([A-Za-z0-9.-_]+)\.([A-Za-z0-9.-_]+)";',
       ),
       (match) {
         final extensionName = match.group(2);

--- a/lib/platforms/ios.dart
+++ b/lib/platforms/ios.dart
@@ -112,7 +112,7 @@ void _setIOSPackageName(dynamic packageName) {
         // `PRODUCT_BUNDLE_IDENTIFIER = {{BUNDLE_ID}};`
         .replaceAll(
           RegExp(
-            r'PRODUCT_BUNDLE_IDENTIFIER = ([A-Za-z0-9.-]+)(?<!\.RunnerTests);',
+            r'PRODUCT_BUNDLE_IDENTIFIER = ([A-Za-z0-9.-_]+)(?<!\.RunnerTests);',
           ),
           'PRODUCT_BUNDLE_IDENTIFIER = $packageName;',
         )
@@ -126,7 +126,7 @@ void _setIOSPackageName(dynamic packageName) {
         // `PRODUCT_BUNDLE_IDENTIFIER = "{{BUNDLE_ID}}.{{EXTENSION_NAME}}";`
         .replaceAllMapped(
       RegExp(
-        r'PRODUCT_BUNDLE_IDENTIFIER = "([A-Za-z0-9.-]+)\.([A-Za-z0-9.-]+)";',
+        r'PRODUCT_BUNDLE_IDENTIFIER = "([A-Za-z0-9.-_]+)\.([A-Za-z0-9.-_]+)";',
       ),
       (match) {
         final extensionName = match.group(2);


### PR DESCRIPTION
When creating project it can be named with underscore: example_project.
Package was not renaming `PRODUCT_BUNDLE_IDENTIFIER` for the following format: com.example.example_project.
This PR adds missing symbol in regex to correctly modify all occurrences of `PRODUCT_BUNDLE_IDENTIFIER`