### PR TITLE
feat: added optional short_app_name web config (#54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ package_rename_config:
     copyright_notice: # (String) The product copyright of the macos app
 
   web:
-    app_name: # (String) The title and display name of the web app and PWA
+    app_name: # (String) The title of the web app and PWA
+    short_app_name: # (String) The short display name of the PWA (Optional, defaults to app_name if not set)
     description: # (String) The description of the web app and PWA
 
   windows:

--- a/example/package_rename_config.yaml
+++ b/example/package_rename_config.yaml
@@ -12,6 +12,7 @@ package_rename_config:
 
   web:
     app_name: Package Rename Demo
+    short_app_name: Package Rename
     description: CLI tool to rename package configurations in Flutter project.
 
   linux:

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -36,6 +36,7 @@ const _projectFileName = 'project.pbxproj';
 // ! Keys
 const _configKey = 'package_rename_config';
 const _appNameKey = 'app_name';
+const _shortAppNameKey = 'short_app_name';
 const _packageNameKey = 'package_name';
 const _bundleNameKey = 'bundle_name';
 const _descriptionKey = 'description';

--- a/lib/exceptions.dart
+++ b/lib/exceptions.dart
@@ -180,4 +180,9 @@ class _PackageRenameErrors {
     _macOSProjectFileNotFoundMessage,
     33,
   );
+
+  static const invalidShortAppName = _PackageRenameException(
+    _invalidShortAppNameMessage,
+    34,
+  );
 }

--- a/lib/messages.dart
+++ b/lib/messages.dart
@@ -43,9 +43,9 @@ const _invalidAppNameMessage = '''
 ''';
 
 const _invalidShortAppNameMessage = '''
-╔═════════════════════════════════════════════════════════════╗
+╔═══════════════════════════════════════════════════════╗
 ║   short_app_name (Short App Name) must be a String.   ║
-╚═════════════════════════════════════════════════════════════╝
+╚═══════════════════════════════════════════════════════╝
 ''';
 
 const _androidMainManifestNotFoundMessage = '''

--- a/lib/messages.dart
+++ b/lib/messages.dart
@@ -42,6 +42,12 @@ const _invalidAppNameMessage = '''
 ╚═══════════════════════════════════════════╝
 ''';
 
+const _invalidShortAppNameMessage = '''
+╔═════════════════════════════════════════════════════════════╗
+║   short_app_name (Short App Name) must be a String.   ║
+╚═════════════════════════════════════════════════════════════╝
+''';
+
 const _androidMainManifestNotFoundMessage = '''
 ╔═══════════════════════════════════════════════════════════════╗
 ║   AndroidManifest.xml not found in `android/app/src/main/`.   ║

--- a/lib/platforms/web.dart
+++ b/lib/platforms/web.dart
@@ -8,7 +8,10 @@ void _setWebConfigurations(dynamic webConfig) {
     final webConfigMap = Map<String, dynamic>.from(webConfig);
 
     _setWebTitle(webConfigMap[_appNameKey]);
-    _setPWAAppName(webConfigMap[_appNameKey]);
+    _setPWAAppName(
+      webConfigMap[_appNameKey],
+      webConfigMap[_shortAppNameKey],
+    );
     _setWebDescription(webConfigMap[_descriptionKey]);
     _setPWADescription(webConfigMap[_descriptionKey]);
   } on _PackageRenameException catch (e) {
@@ -59,10 +62,11 @@ void _setWebTitle(dynamic appName) {
   }
 }
 
-void _setPWAAppName(dynamic appName) {
+void _setPWAAppName(dynamic appName, dynamic shortAppName) {
   try {
     if (appName == null) return;
     if (appName is! String) throw _PackageRenameErrors.invalidAppName;
+    final actualShortAppName = shortAppName is String ? shortAppName : appName;
 
     final webManifestFile = File(_webManifestFilePath);
     if (!webManifestFile.existsSync()) {
@@ -76,21 +80,22 @@ void _setPWAAppName(dynamic appName) {
     ) as Map<String, dynamic>;
 
     webManifestJson['name'] = appName;
-    webManifestJson['short_name'] = appName;
+    webManifestJson['short_name'] = actualShortAppName;
 
     const encoder = JsonEncoder.withIndent('    ');
     webManifestFile.writeAsStringSync('${encoder.convert(webManifestJson)}\n');
 
     _logger.i('PWA name set to: `$appName` (manifest.json)');
+    _logger.i('PWA short name set to: `$actualShortAppName` (manifest.json)');
   } on _PackageRenameException catch (e) {
     _logger
       ..e('${e.message}ERR Code: ${e.code}')
-      ..e('PWA Name change failed!!!');
+      ..e('PWA Name/Short Name change failed!!!');
   } catch (e) {
     _logger
       ..w(e.toString())
       ..e('ERR Code: 255')
-      ..e('PWA Name change failed!!!');
+      ..e('PWA Name/Short Name change failed!!!');
   } finally {
     if (appName != null) _logger.f(_minorTaskDoneLine);
   }

--- a/lib/platforms/web.dart
+++ b/lib/platforms/web.dart
@@ -66,6 +66,10 @@ void _setPWAAppName(dynamic appName, dynamic shortAppName) {
   try {
     if (appName == null) return;
     if (appName is! String) throw _PackageRenameErrors.invalidAppName;
+
+    if (shortAppName != null && shortAppName is! String) {
+      throw _PackageRenameErrors.invalidShortAppName;
+    }
     final actualShortAppName = shortAppName is String ? shortAppName : appName;
 
     final webManifestFile = File(_webManifestFilePath);


### PR DESCRIPTION
Fixes #54.

This PR introduces a new feature that allows setting the `short_name` parameter in the `manifest.json` file independently from the `name` parameter for web configurations.

Currently, the `app_name` parameter is used to set both `name` and `short_name` in the `manifest.json` file. With this change, we split the `app_name` parameter into `app_name` and `short_app_name` to provide more flexibility.

The `short_app_name` parameter is optional, and if not provided, it will default to the value of `app_name`.

**Note:**

The error codes and messages used in the catch blocks are not actually used in the codebase. Please advise if these should be removed or if there are any plans to utilize them in the future.
