### PR TITLE
v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.10.0
+
+- feat(android): prefer Kotlin DSL (`.gradle.kts`) over Groovy DSL (`.gradle`) when available in [09409d6](https://github.com/OutdatedGuy/package_rename/commit/09409d61081ad9ee6a382e975e953e4281e52ccf)
+- fix(android): correctly verify `build.gradle` file, resolving issues in projects using the Groovy DSL (.gradle) in [0ca8d35](https://github.com/OutdatedGuy/package_rename/commit/0ca8d35797193d4b5dff66fb2f2ce3bc2eb20c85)
+- chore: updated dependencies to latest in [1caa584](https://github.com/OutdatedGuy/package_rename/commit/1caa5840cc89cdd4529f5a0e3d2f79ec18297ae0)
+
 ## 1.9.0
 
 - feat(android): Added support for Flutter 3.29 template in [4cc8e82](https://github.com/OutdatedGuy/package_rename/commit/4cc8e821f829ae0de107f5c6b77321bebdde182c)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For more info see [list of changed fields](CHANGED_FIELDS.md)
 
 ```yaml
 dev_dependencies:
-  package_rename: ^1.9.0
+  package_rename: ^1.10.0
 ```
 
 #### Create configuration

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -92,7 +92,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.9.0"
+    version: "1.10.0"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_rename
 description: "A Blazingly Fast way to configure your awesome flutter project to be production ready."
-version: 1.9.0
+version: 1.10.0
 homepage: https://outdatedguy.rocks
 repository: https://github.com/OutdatedGuy/package_rename
 topics:


### PR DESCRIPTION
## What's Changed
* fix: `build.gradle` file not checked properly by @OutdatedGuy in https://github.com/OutdatedGuy/package_rename/pull/80
* fix: lint checking fails on Github Actions by @OutdatedGuy in https://github.com/OutdatedGuy/package_rename/pull/81
* refactor: prefer `.gradle.kts` file over `.gradle` if present by @OutdatedGuy in https://github.com/OutdatedGuy/package_rename/pull/82
* chore: updated dependencies to latest by @OutdatedGuy in https://github.com/OutdatedGuy/package_rename/pull/83


**Full Changelog**: https://github.com/OutdatedGuy/package_rename/compare/v1.9.0...v1.10.0